### PR TITLE
fix:sso api config

### DIFF
--- a/examples/single-sign-on/.env.local.example
+++ b/examples/single-sign-on/.env.local.example
@@ -1,0 +1,10 @@
+# Client (public) env vars
+
+# the URL of this example + where the api routes are located
+NEXT_PUBLIC_BASE_PATH=http://localhost:3000/api
+
+# The URL of the Nile API
+NILE_BASE_PATH=https://dev.khnum.thenile.dev
+
+WORKSPACE=
+DATABASE=

--- a/examples/single-sign-on/nile/Server.ts
+++ b/examples/single-sign-on/nile/Server.ts
@@ -4,7 +4,7 @@ const nile = Server({
   workspace: String(process.env.WORKSPACE),
   database: String(process.env.DATABASE),
   api: {
-    basePath: 'http://localhost:8080',
+    basePath: String(process.env.NILE_BASE_PATH),
   },
 });
 


### PR DESCRIPTION
This allows the example to run against a non-local configuration, and adds an `.env.local.example` for defining the necessary environment variables.