### PR TITLE
feat: google signup form with tenant name

### DIFF
--- a/packages/react/src/GoogleLoginButton/GoogleLoginButton.stories.tsx
+++ b/packages/react/src/GoogleLoginButton/GoogleLoginButton.stories.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { CssVarsProvider } from '@mui/joy/styles';
+import Stack from '@mui/joy/Stack';
+import Input from '@mui/joy/Input';
 
 import { NileProvider } from '../context';
 import defaultTheme from '../context/theme';
@@ -23,6 +25,27 @@ export function Basic() {
     </NileProvider>
   );
 }
+
+export function BasicWithTenantNameProvider() {
+  const [newTenant, setNewTenant] = React.useState<string | undefined>();
+  return (
+    <NileProvider>
+      <div style={{ maxWidth: '20rem', margin: '0 auto' }}>
+        <Stack gap={2}>
+          <Stack>
+            <Input
+              size="sm"
+              placeholder="Organization Name"
+              onChange={(event) => setNewTenant(event.target.value)}
+            />
+          </Stack>
+          <GoogleLoginButton newTenantName={newTenant} />
+        </Stack>
+      </div>
+    </NileProvider>
+  );
+}
+
 export function AlphaVersionWithOutProvider() {
   return (
     <CssVarsProvider theme={defaultTheme}>

--- a/packages/react/src/GoogleLoginButton/GoogleLoginButton.tsx
+++ b/packages/react/src/GoogleLoginButton/GoogleLoginButton.tsx
@@ -13,7 +13,7 @@ import GoogleLogo from './google.svg';
 const LOGIN_PATH = 'users/oidc/google/login';
 
 /**
- * A compponent for a Google login button, according to their design language.
+ * A component for a Google login button, according to their design language.
  * This works when an identity provider is configured in the admin dashboard.
  * @param props href: a string to override the URL provided by the context
  * @returns a JSX.Element to render
@@ -22,13 +22,15 @@ export default function GoogleSSOButton(props: {
   href?: string;
   workspace?: string;
   database?: string;
+  newTenantName?: string;
 }) {
-  const { workspace, database } = props;
+  const { workspace, database, newTenantName } = props;
   const { basePath } = useNileConfig();
   // workspace and database can be `''`.
   // let this fail silently for now, and update the context when the time comes
   const contextHref = `${basePath}/workspaces/${workspace}/databases/${database}/${LOGIN_PATH}`;
-  const href = props?.href ?? contextHref;
+  const query = newTenantName ? '?newTenant=' + newTenantName : '';
+  const href = (props?.href ?? contextHref) + query;
   return (
     <Box
       component="a"

--- a/packages/react/src/GoogleLoginButton/GoogleLoginButton.tsx
+++ b/packages/react/src/GoogleLoginButton/GoogleLoginButton.tsx
@@ -26,10 +26,12 @@ export default function GoogleSSOButton(props: {
 }) {
   const { workspace, database, newTenantName } = props;
   const { basePath } = useNileConfig();
-  // workspace and database can be `''`.
-  // let this fail silently for now, and update the context when the time comes
-  const contextHref = `${basePath}/workspaces/${workspace}/databases/${database}/${LOGIN_PATH}`;
-  const query = newTenantName ? '?newTenant=' + newTenantName : '';
+  const encodedWorkspace = encodeURIComponent(workspace ?? '');
+  const encodedDatabase = encodeURIComponent(database ?? '');
+  const contextHref = `${basePath}/workspaces/${encodedWorkspace}/databases/${encodedDatabase}/${LOGIN_PATH}`;
+  const query = newTenantName
+    ? '?newTenant=' + encodeURIComponent(newTenantName)
+    : '';
   const href = (props?.href ?? contextHref) + query;
   return (
     <Box


### PR DESCRIPTION
This adds a prop to the `GoogleLoginButton` component to allow a user to specify a tenant name to create during signup. The storybook includes an example that acquires the name from an input field and sets the attribute.