### PR TITLE
fix(server): include lodash-es for esm imports

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -50,6 +50,7 @@
     "@babel/core": "^7.23.3",
     "@types/jest": "^29.5.9",
     "@types/lodash": "^4",
+    "@types/lodash-es": "^4",
     "@types/mime": "^4.0.0",
     "@types/pg": "^8.11.4",
     "@typescript-eslint/parser": "^5.62.0",
@@ -70,6 +71,7 @@
     "dotenv": "^16.4.5",
     "jose": "^4.15.4",
     "lodash": "^4.17.21",
+    "lodash-es": "^4.17.21",
     "pg": "^8.11.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3460,6 +3460,7 @@ __metadata:
     "@babel/core": "npm:^7.23.3"
     "@types/jest": "npm:^29.5.9"
     "@types/lodash": "npm:^4"
+    "@types/lodash-es": "npm:^4"
     "@types/mime": "npm:^4.0.0"
     "@types/pg": "npm:^8.11.4"
     "@typescript-eslint/parser": "npm:^5.62.0"
@@ -3474,6 +3475,7 @@ __metadata:
     jest-environment-jsdom: "npm:^29.7.0"
     jose: "npm:^4.15.4"
     lodash: "npm:^4.17.21"
+    lodash-es: "npm:^4.17.21"
     pg: "npm:^8.11.3"
     size-limit: "npm:^8.2.6"
     ts-jest: "npm:^29.1.1"
@@ -5821,7 +5823,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash@npm:^4, @types/lodash@npm:^4.14.167":
+"@types/lodash-es@npm:^4":
+  version: 4.17.12
+  resolution: "@types/lodash-es@npm:4.17.12"
+  dependencies:
+    "@types/lodash": "npm:*"
+  checksum: 10/56b9a433348b11c31051c6fa9028540a033a08fb80b400c589d740446c19444d73b217cf1471d4036448ef686a83e8cf2a35d1fadcb3f2105f26701f94aebb07
+  languageName: node
+  linkType: hard
+
+"@types/lodash@npm:*, @types/lodash@npm:^4, @types/lodash@npm:^4.14.167":
   version: 4.17.0
   resolution: "@types/lodash@npm:4.17.0"
   checksum: 10/2053203292b5af99352d108656ceb15d39da5922fc3fb8186e1552d65c82d6e545372cc97f36c95873aa7186404d59d9305e9d49254d4ae55e77df1e27ab7b5d
@@ -14144,6 +14155,13 @@ __metadata:
   dependencies:
     p-locate: "npm:^6.0.0"
   checksum: 10/1c6d269d4efec555937081be964e8a9b4a136319c79ca1d45ac6382212a8466113c75bd89e44521ca8ecd1c47fb08523b56eee5c0712bc7d14fec5f729deeb42
+  languageName: node
+  linkType: hard
+
+"lodash-es@npm:^4.17.21":
+  version: 4.17.21
+  resolution: "lodash-es@npm:4.17.21"
+  checksum: 10/03f39878ea1e42b3199bd3f478150ab723f93cc8730ad86fec1f2804f4a07c6e30deaac73cad53a88e9c3db33348bb8ceeb274552390e7a75d7849021c02df43
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
but where lodash-es is subbed for lodash in the build, so include that dep