### PR TITLE
[feat] add sign out

### DIFF
--- a/packages/server/src/api/utils/auth.ts
+++ b/packages/server/src/api/utils/auth.ts
@@ -3,6 +3,29 @@ import Logger from '../../utils/Logger';
 
 import request from './request';
 
+type ProviderName =
+  | 'discord'
+  | 'github'
+  | 'google'
+  | 'hubspot'
+  | 'linkedin'
+  | 'slack'
+  | 'twitter'
+  | 'email'
+  | 'credentials'
+  | 'azure';
+
+export type Providers = {
+  [providerName in ProviderName]: Provider;
+};
+export type Provider = {
+  id: string;
+  name: string;
+  type: string;
+  signinUrl: string;
+  callbackUr: string;
+};
+
 export type JWT = {
   email: string;
   sub: string;

--- a/packages/server/src/api/utils/routes/defaultRoutes.ts
+++ b/packages/server/src/api/utils/routes/defaultRoutes.ts
@@ -17,5 +17,5 @@ export const appRoutes = (prefix = '/api'): Routes => ({
   TENANT_USER: `${prefix}/tenants/{tenantId}/users/{userId}`,
   TENANT_USERS: `${prefix}/tenants/{tenantId}/users`,
   SIGNUP: `${prefix}/signup`,
-  LOG: `${prefix}/auth/_log`,
+  LOG: `${prefix}/_log`,
 });

--- a/packages/server/src/auth/auth.test.ts
+++ b/packages/server/src/auth/auth.test.ts
@@ -14,8 +14,10 @@ const baseConfig = [
   'headers',
   'logger',
   'password',
+  'listProviders',
   'getSession',
   'user',
+  'signOut',
 ];
 const apiConfig = [
   '_token',

--- a/packages/server/src/utils/Requester/index.ts
+++ b/packages/server/src/utils/Requester/index.ts
@@ -18,9 +18,9 @@ export default class Requester<T> extends Config {
     body?: string
   ): Promise<Response> {
     const _init = {
-      ...init,
       body,
       method,
+      ...init,
     };
 
     const res = await _fetch(this, url, _init);

--- a/packages/server/src/utils/fetch.ts
+++ b/packages/server/src/utils/fetch.ts
@@ -168,7 +168,9 @@ export async function _fetch(
       typeof response?.clone === 'function' ? response.clone() : null;
     let msg = '';
     try {
-      res = await (response as Response)?.json();
+      res = await (response as Response)?.json().catch(() => {
+        // handle below
+      });
     } catch (e) {
       if (errorHandler) {
         msg = await errorHandler.text();
@@ -202,7 +204,8 @@ export async function _fetch(
     error(
       `[fetch][response][status: ${errorHandler?.status}] UNHANDLED ERROR`,
       {
-        res,
+        response,
+        message: await response.text(),
       }
     );
     return new ResponseError(null, {


### PR DESCRIPTION
Adds the ability to sign out server side.

Grabs the CSRF token to pass along, so its a 2 step process, just like the browser.

To keep everything in sync and be sure everything comes back from the API, this works like
```
  nile.api.headers = new Headers({ cookie: nextCookies.toString() });
  const res = await nile.api.auth.signOut();
```

We introspect the `callback-url` cookie and set that as the origin, so nile-auth does the right thing for the url returned in the request.

This will return a `{url}` if it works, which is the `callbackUrl` (url to be redirected to on log out), which is exactly the same as the client side version.

As always, these APIs are designed to work within a user context, so signing out by random user.id isn't supported.