### PR TITLE
feat(server): add sign out, return raw res for login

### DIFF
--- a/packages/server/src/auth/auth.test.ts
+++ b/packages/server/src/auth/auth.test.ts
@@ -17,6 +17,7 @@ const baseConfig = [
   'listProviders',
   'getSession',
   'user',
+  'resetHeaders',
   'signOut',
 ];
 const apiConfig = [

--- a/packages/server/src/tenants/index.ts
+++ b/packages/server/src/tenants/index.ts
@@ -30,10 +30,10 @@ export default class Tenants extends Config {
     return `/tenants/${this.tenantId ?? '{tenantId}'}`;
   }
 
-  createTenant = async (
+  createTenant = async <T = Tenant | Response>(
     req: NileRequest<{ name: string }> | Headers | string,
     init?: RequestInit
-  ): Promise<Tenant | Response> => {
+  ): Promise<T> => {
     let _req;
     if (typeof req === 'string') {
       _req = new Request(`${this.api.basePath}${this.tenantsUrl}`, {
@@ -48,49 +48,49 @@ export default class Tenants extends Config {
     }
     const _requester = new Requester(this);
     const _init = this.handleHeaders(init);
-    return _requester.post(_req, this.tenantsUrl, _init);
+    return _requester.post(_req, this.tenantsUrl, _init) as T;
   };
 
-  getTenant = async (
+  getTenant = async <T = Tenant | Response>(
     req: NileRequest<{ id: string }> | Headers | string | void,
     init?: RequestInit
-  ): Promise<Tenant | Response> => {
+  ): Promise<T> => {
     if (typeof req === 'string') {
       this.tenantId = req;
     }
     const _requester = new Requester(this);
     const _init = this.handleHeaders(init);
-    return _requester.get<Tenant>(req, this.tenantUrl, _init);
+    return _requester.get<Tenant>(req, this.tenantUrl, _init) as T;
   };
 
   get tenantListUrl() {
     return `/users/${this.userId ?? '{userId}'}/tenants`;
   }
 
-  listTenants = async (
+  listTenants = async <T = Tenant[] | Response>(
     req: NileRequest<void> | Headers,
     init?: RequestInit
-  ): Promise<Tenant[] | Response> => {
+  ): Promise<T> => {
     const _requester = new Requester(this);
     const _init = this.handleHeaders(init);
-    return _requester.get<Tenant[]>(req, this.tenantListUrl, _init);
+    return _requester.get<Tenant[]>(req, this.tenantListUrl, _init) as T;
   };
 
-  deleteTenant = async (
+  deleteTenant = async <T = Response>(
     req: NileRequest<void> | Headers | string,
     init?: RequestInit
-  ): Promise<Response> => {
+  ): Promise<T> => {
     if (typeof req === 'string') {
       this.tenantId = req;
     }
     const _requester = new Requester(this);
     const _init = this.handleHeaders(init);
-    return _requester.delete(req, this.tenantUrl, _init);
+    return _requester.delete(req, this.tenantUrl, _init) as T;
   };
-  updateTenant = async (
+  updateTenant = async <T = Tenant | Response>(
     req: NileRequest<void> | Headers | { name: string },
     init?: RequestInit
-  ): Promise<Tenant | Response> => {
+  ): Promise<T> => {
     let _req;
     if (req && 'name' in req) {
       _req = new Request(`${this.api.basePath}${this.tenantUrl}`, {
@@ -102,6 +102,6 @@ export default class Tenants extends Config {
     }
     const _requester = new Requester(this);
     const _init = this.handleHeaders(init);
-    return _requester.put<Tenant>(_req, this.tenantUrl, _init);
+    return _requester.put<Tenant>(_req, this.tenantUrl, _init) as T;
   };
 }

--- a/packages/server/src/users/index.ts
+++ b/packages/server/src/users/index.ts
@@ -43,32 +43,32 @@ export default class Users extends Config {
     return undefined;
   }
 
-  createUser = async (
+  createUser = async <T = User | Response>(
     req: NileRequest<CreateBasicUserRequest>,
     init?: RequestInit
-  ): Promise<User | Response> => {
+  ): Promise<T> => {
     const _requester = new Requester(this);
 
     const _init = this.handleHeaders(init);
-    return await _requester.post(req, this.usersUrl, _init);
+    return (await _requester.post(req, this.usersUrl, _init)) as T;
   };
 
-  createTenantUser = async (
+  createTenantUser = async <T = User | Response>(
     req: NileRequest<CreateBasicUserRequest>,
     init?: RequestInit
-  ): Promise<User | Response> => {
+  ): Promise<T> => {
     const _requester = new Requester(this);
 
     const _init = this.handleHeaders(init);
-    return await _requester.post(req, this.tenantUsersUrl, _init);
+    return (await _requester.post(req, this.tenantUsersUrl, _init)) as T;
   };
 
-  updateUser = async (
+  updateUser = async <T = User[] | Response>(
     req: NileRequest<
       Partial<Omit<User, 'email' | 'tenants' | 'created' | 'updated'>>
     >,
     init?: RequestInit
-  ): Promise<User | Response> => {
+  ): Promise<T> => {
     let _req;
     if (req && 'id' in req) {
       _req = new Request(`${this.api.basePath}${this.tenantUserUrl}`, {
@@ -81,22 +81,22 @@ export default class Users extends Config {
     }
     const _requester = new Requester(this);
     const _init = this.handleHeaders(init);
-    return await _requester.put(_req, this.tenantUserUrl, _init);
+    return (await _requester.put(_req, this.tenantUserUrl, _init)) as T;
   };
 
-  listUsers = async (
+  listUsers = async <T = User[] | Response>(
     req: NileRequest<void> | Headers,
     init?: RequestInit
-  ): Promise<User[] | Response> => {
+  ): Promise<T> => {
     const _requester = new Requester(this);
     const _init = this.handleHeaders(init);
-    return await _requester.get(req, this.tenantUsersUrl, _init);
+    return (await _requester.get(req, this.tenantUsersUrl, _init)) as T;
   };
 
-  linkUser = async (
+  linkUser = async <T = User | Response>(
     req: NileRequest<{ id: string; tenantId?: string }> | Headers | string,
     init?: RequestInit
-  ): Promise<User | Response> => {
+  ): Promise<T> => {
     const _requester = new Requester(this);
     if (typeof req === 'string') {
       this.userId = req;
@@ -110,13 +110,13 @@ export default class Users extends Config {
     }
 
     const _init = this.handleHeaders(init);
-    return await _requester.put(req, this.linkUsersUrl, _init);
+    return (await _requester.put(req, this.linkUsersUrl, _init)) as T;
   };
 
-  unlinkUser = async (
+  unlinkUser = async <T = Response>(
     req: NileRequest<{ id: string; tenantId?: string }> | Headers | string,
     init?: RequestInit
-  ): Promise<Response> => {
+  ): Promise<T> => {
     if (typeof req === 'string') {
       this.userId = req;
     } else {
@@ -129,7 +129,7 @@ export default class Users extends Config {
     }
     const _requester = new Requester(this);
     const _init = this.handleHeaders(init);
-    return await _requester.delete(req, this.linkUsersUrl, _init);
+    return (await _requester.delete(req, this.linkUsersUrl, _init)) as T;
   };
 
   get meUrl() {
@@ -144,7 +144,7 @@ export default class Users extends Config {
     const _init = this.handleHeaders(init);
     return await _requester.get(req, this.meUrl, _init);
   };
-  updateMe = async (
+  updateMe = async <T = User | Response>(
     req:
       | NileRequest<
           Partial<
@@ -153,9 +153,9 @@ export default class Users extends Config {
         >
       | Headers,
     init?: RequestInit
-  ): Promise<User | Response> => {
+  ): Promise<T> => {
     const _requester = new Requester(this);
     const _init = this.handleHeaders(init);
-    return await _requester.put(req, this.meUrl, _init);
+    return (await _requester.put(req, this.meUrl, _init)) as T;
   };
 }

--- a/packages/server/src/utils/Requester/index.ts
+++ b/packages/server/src/utils/Requester/index.ts
@@ -117,9 +117,13 @@ export default class Requester<T> extends Config {
   async get<R = JSON>(
     req: T | Headers,
     url: string,
-    init?: RequestInit
+    init?: RequestInit,
+    raw = false
   ): Promise<Response | R> {
     const response = await this.request('GET', url, req, init);
+    if (raw) {
+      return response;
+    }
     if (response && response.status >= 200 && response.status < 300) {
       const cloned = response.clone();
       try {

--- a/packages/server/test/integration/integration.test.ts
+++ b/packages/server/test/integration/integration.test.ts
@@ -41,6 +41,18 @@ describe('api integration', () => {
     const update = {
       name: 'updatedName',
     };
+
+    const res = await nile.api.auth.signOut();
+
+    expect(res.url).not.toBeNull();
+
+    const failedUpdatedFirstUser = await nile.api.users.updateMe<Response>(
+      update
+    );
+    expect(failedUpdatedFirstUser.status).toEqual(401);
+
+    await nile.api.login(primaryUser);
+
     const updatedFirstUser = await nile.api.users.updateMe(update);
 
     expect(updatedFirstUser).toMatchObject({

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -24,7 +24,7 @@
     // error out if import and file system have a casing mismatch. Recommended by TS
     "forceConsistentCasingInFileNames": true,
     // `dts build` ignores this option, but it is commonly used when type-checking separately with `tsc`
-    "noEmit": false
+    "noEmit": false,
   }
   
 }


### PR DESCRIPTION
I still have to test this against dev.

Adds a signOut method for the server. 

```typescript
const res = await nile.api.auth.signOut({
  callbackUrl: "http://localhost:3000",
});

expect(res.url).toEqual("http://localhost:3000");

const failedUpdatedFirstUser = await nile.api.users.updateMe<Response>(update);
expect(failedUpdatedFirstUser.status).toEqual(401);

```

Also adds an option to return the nile-auth response from login, to be passed to a client.

```typescript
const res = await nile.api.login({ email, password }, { setCookie: true });

//has `set-cookie=__Secure.nile_session=`

return res;
```