### PR TITLE
fix: include baseURL when getting session for signedin/signedout

### DIFF
--- a/packages/react/lib/auth/index.tsx
+++ b/packages/react/lib/auth/index.tsx
@@ -186,7 +186,7 @@ export function SessionProvider(props: SessionProviderProps) {
       auth.initialize({ baseUrl: props.baseUrl, session: props.session });
     } else {
       if (!auth.status) {
-        auth.getSession();
+        auth.getSession({ baseUrl: props.baseUrl });
       }
     }
   }, [props.baseUrl, props.session]);

--- a/packages/react/src/SignUpForm/types.ts
+++ b/packages/react/src/SignUpForm/types.ts
@@ -1,5 +1,11 @@
-import { CreateBasicUserRequest } from '@niledatabase/browser';
 import { PrefetchParams } from 'packages/react/lib/utils';
+
+export interface CreateBasicUserRequest {
+  email: string;
+  password: string;
+  preferredName?: string;
+  newTenant?: string;
+}
 
 export type SignUpInfo = CreateBasicUserRequest & {
   tenantId?: string;


### PR DESCRIPTION
This fix uses baseUrl when getting session for the `<SignedIn>` and `<SignedOut>` wrapper components. Allowing them to be used with separate backend.  The issue was originally reported by "Joaquín" on our Discord.

The modifications to `SignUpForm/types.ts` is unrelated, but I couldn't build and test locally without it. Since the type is missing from `@niledatabase/browser`. 