### PR TITLE
fix: making sure login returned the auth info all the way to the caller

### DIFF
--- a/packages/server/src/Api.ts
+++ b/packages/server/src/Api.ts
@@ -104,14 +104,8 @@ export class Api {
     return this._headers;
   }
 
-  login = async (
-    payload: { email: string; password: string },
-    config?: { setCookie?: boolean }
-  ) => {
-    this.headers = await serverLogin(this.config, this.handlers)(
-      payload,
-      config
-    );
+  login = async (payload: { email: string; password: string }) => {
+    this.headers = await serverLogin(this.config, this.handlers)(payload);
     return this.headers;
   };
 

--- a/packages/server/src/Api.ts
+++ b/packages/server/src/Api.ts
@@ -112,6 +112,7 @@ export class Api {
       payload,
       config
     );
+    return this.headers;
   };
 
   session = async (req?: Request | Headers | null | undefined) => {

--- a/packages/server/src/Api.ts
+++ b/packages/server/src/Api.ts
@@ -104,9 +104,19 @@ export class Api {
     return this._headers;
   }
 
-  login = async (payload: { email: string; password: string }) => {
-    this.headers = await serverLogin(this.config, this.handlers)(payload);
-    return this.headers;
+  login = async (
+    payload: { email: string; password: string },
+    config?: { returnResponse?: boolean }
+  ) => {
+    const [headers, loginRes] = await serverLogin(
+      this.config,
+      this.handlers
+    )(payload);
+    this.headers = headers;
+    if (config?.returnResponse) {
+      return loginRes;
+    }
+    return undefined; // preserve existing behavior where login returns undefined
   };
 
   session = async (req?: Request | Headers | null | undefined) => {

--- a/packages/server/src/auth/index.ts
+++ b/packages/server/src/auth/index.ts
@@ -21,18 +21,13 @@ export function serverLogin(
 ) {
   const { info, error, debug } = Logger(config, '[server side login]');
   const routes = appRoutes(config.api.routePrefix);
-  return async function login<T = Response | Headers | Error>(
-    {
-      email,
-      password,
-    }: {
-      email: string;
-      password: string;
-    },
-    loginConfig?: {
-      setCookie?: boolean;
-    }
-  ) {
+  return async function login<T = Response | Headers | Error>({
+    email,
+    password,
+  }: {
+    email: string;
+    password: string;
+  }) {
     if (!email || !password) {
       throw new Error('Server side login requires a user email and password.');
     }
@@ -115,10 +110,6 @@ export function serverLogin(
     const authCookie = loginRes?.headers.get('set-cookie');
     if (!authCookie) {
       throw new Error('authentication failed');
-    }
-
-    if (loginConfig?.setCookie) {
-      return loginRes as T;
     }
 
     const [, token] =

--- a/packages/server/src/auth/index.ts
+++ b/packages/server/src/auth/index.ts
@@ -21,7 +21,7 @@ export function serverLogin(
 ) {
   const { info, error, debug } = Logger(config, '[server side login]');
   const routes = appRoutes(config.api.routePrefix);
-  return async function login<T = Response | Headers | Error>({
+  return async function login<T extends [Headers, Response]>({
     email,
     password,
   }: {
@@ -123,7 +123,7 @@ export function serverLogin(
       ...baseHeaders,
       cookie: [token, csrfCookie].join('; '),
     });
-    return headers as T;
+    return [headers, loginRes] as T;
   };
 }
 

--- a/packages/server/test/integration/integration.test.ts
+++ b/packages/server/test/integration/integration.test.ts
@@ -34,7 +34,8 @@ describe('api integration', () => {
 
     expect(user.id).toBeTruthy();
 
-    await nile.api.login(primaryUser);
+    const loginRes = await nile.api.login(primaryUser);
+    expect(loginRes.get('cookie')).toBeDefined();
 
     // Updating session user
     expect(user.name).toEqual(null);

--- a/packages/server/test/integration/integration.test.ts
+++ b/packages/server/test/integration/integration.test.ts
@@ -34,8 +34,10 @@ describe('api integration', () => {
 
     expect(user.id).toBeTruthy();
 
-    const loginRes = await nile.api.login(primaryUser);
-    expect(loginRes.get('cookie')).toBeDefined();
+    const loginRes = await nile.api.login(primaryUser, {
+      returnResponse: true,
+    });
+    expect(loginRes?.headers.get('cookie')).toBeDefined();
 
     // Updating session user
     expect(user.name).toEqual(null);


### PR DESCRIPTION
- Propagating the returned value of `ServerLogin` via the API layer
- Because of the extra handling in the API layer, `ServerLogin` has to return headers. 
- In addition, the headers seem sufficient for developers to handle the user login (either they contain session-token that can be used later or login failed). 
- No need for a config, we can always return the headers and let the developers decide whether to use them or not.