### PR TITLE
chore(server): add test for header merging

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -1,16 +1,12 @@
 name: Publish @niledatabase packages
 
 on:
-  workflow_run:
-    workflows: ["test"]
-    types:
-      - completed
+  push:
+    branches: [main]
 
 jobs:
   publish:
-    if: >
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_branch == 'main'
+    needs: test
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -26,17 +22,14 @@ jobs:
       - name: Enable Corepack before setting up Node
         run: corepack enable
 
-      # Setup .npmrc file to publish to GitHub Packages
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: "20.x"
-          # registry-url: 'https://npm.pkg.github.com'
-          # Defaults to the user or organization that owns the workflow file
-          # scope: '@niledatabase'
+
       - name: Authenticate to npm
         run: |
-          echo "@niledatabase:wq:registry=https://registry.npmjs.org/" 
+          echo "@niledatabase:registry=https://registry.npmjs.org/" >> .npmrc
           echo "registry=https://registry.npmjs.org/" >> .npmrc
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
           npm whoami
@@ -77,7 +70,7 @@ jobs:
         run: |
           npx lerna publish from-git --yes
 
-      - name: Update npm for git
+      - name: Update npmrc for GitHub
         run: |
           rm -rf .npmrc
           echo "@niledatabase:registry=https://npm.pkg.github.com/" >> .npmrc
@@ -86,7 +79,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.PAT }}
 
-      - name: Publish to git
+      - name: Publish to GitHub Packages
         run: npx lerna publish from-git --yes --registry=https://npm.pkg.github.com/
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,10 +1,8 @@
 name: test
 
 on:
-  push:
-    branches:
-      - "**"
-
+  pull_request:
+    branches: [main, stable]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/packages/react/lib/auth/Authorizer.ts
+++ b/packages/react/lib/auth/Authorizer.ts
@@ -509,7 +509,7 @@ export default class Authorizer {
       return;
     }
 
-    if (options?.redirect ?? true) {
+    if ((options?.redirect ?? true) && !error) {
       const url = callbackUrl;
       window.location.href = url;
       // If url contains a hash, the browser does not reload the page. We reload manually

--- a/packages/server/src/Server.test.ts
+++ b/packages/server/src/Server.test.ts
@@ -111,4 +111,23 @@ describe('server', () => {
     // routes are not configurable server side
     expect(nile.api.users.tenantUsersUrl).toEqual('/tenants/{tenantId}/users');
   });
+  it('merges headers', () => {
+    const nile = new Server();
+    expect(nile.api.headers).toEqual(undefined);
+    nile.api.headers = { cookie: '123' };
+    let update: [string, string][] = [];
+    nile.api.headers?.forEach((value, key) => {
+      update.push([key.toLowerCase(), value]);
+    });
+    expect(update).toEqual([['cookie', '123']]);
+    update = [];
+    nile.api.headers = { host: 'localhost:3000' };
+    nile.api.headers?.forEach((value, key) => {
+      update.push([key.toLowerCase(), value]);
+    });
+    expect(update).toEqual([
+      ['cookie', '123'],
+      ['host', 'localhost:3000'],
+    ]);
+  });
 });

--- a/packages/server/src/api/utils/request.test.ts
+++ b/packages/server/src/api/utils/request.test.ts
@@ -1,0 +1,142 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Config } from '../../utils/Config';
+import { setContext, setCookie } from '../../context/asyncStorage';
+
+jest.mock('../../context/asyncStorage', () => ({
+  setContext: jest.fn(),
+  setCookie: jest.fn(),
+}));
+
+import _request from './request';
+
+describe('request', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('sets the correct GET headers', async () => {
+    global.fetch = jest.fn((url, p) => {
+      return Promise.resolve({
+        ...p,
+        status: 200,
+      }) as unknown as Promise<Response>;
+    });
+    const request = new Request('http://localhost:3001/v2/databases/123');
+    const config = new Config();
+    const res = await _request('http://localhost:3000', { request }, config);
+    const expectedHeaders: any = {
+      host: 'localhost:3001',
+      'nile.origin': 'http://localhost:3001',
+    };
+    const headersObject = Object.entries(
+      Object.fromEntries(res.headers.entries())
+    );
+    expect(headersObject.length).toBe(2);
+    for (const [key, value] of headersObject) {
+      const val = expectedHeaders[key];
+      expect(value).toBe(val);
+    }
+  });
+  it('sets the correct POST headers', async () => {
+    global.fetch = jest.fn((url, p) => {
+      return Promise.resolve({
+        ...p,
+        status: 200,
+      }) as unknown as Promise<Response>;
+    });
+    const request = new Request('http://localhost:3001/v2/databases/123', {
+      method: 'POST',
+      body: 'userID=1234',
+    });
+    const config = new Config();
+    const res = await _request(
+      'http://localhost:3000',
+      { request, method: 'POST' },
+      config
+    );
+    const expectedHeaders: any = {
+      host: 'localhost:3001',
+      'nile.origin': 'http://localhost:3001',
+      'content-type': 'application/x-www-form-urlencoded',
+    };
+    const headersObject = Object.entries(
+      Object.fromEntries(res.headers.entries())
+    );
+    expect(headersObject.length).toBe(3);
+    for (const [key, value] of headersObject) {
+      const val = expectedHeaders[key];
+      expect(value).toBe(val);
+    }
+  });
+  it('sets the correct PUT headers', async () => {
+    global.fetch = jest.fn((url, p) => {
+      return Promise.resolve({
+        ...p,
+        status: 200,
+      }) as unknown as Promise<Response>;
+    });
+    const request = new Request('http://localhost:3001/v2/databases/123', {
+      method: 'PUT',
+      body: JSON.stringify({ userID: '1234' }),
+    });
+    const config = new Config();
+    const res = await _request(
+      'http://localhost:3000',
+      { request, method: 'POST' },
+      config
+    );
+    const expectedHeaders: any = {
+      host: 'localhost:3001',
+      'nile.origin': 'http://localhost:3001',
+      'content-type': 'application/json',
+    };
+    const headersObject = Object.entries(
+      Object.fromEntries(res.headers.entries())
+    );
+
+    expect(headersObject.length).toBe(3);
+    for (const [key, value] of headersObject) {
+      const val = expectedHeaders[key];
+      expect(value).toBe(val);
+    }
+  });
+  it('sets the context', async () => {
+    const requestHeaders = {
+      host: 'localhost:3001',
+    };
+
+    global.fetch = jest.fn().mockResolvedValue({
+      headers: new Headers({
+        'set-cookie': 'nile.session-token=123',
+      }),
+      status: 200,
+    });
+
+    const request = {
+      url: 'http://localhost:3001/v2/databases/123',
+      method: 'PUT',
+      headers: new Headers(),
+      clone: jest.fn(() => ({ body: '' })),
+      body: JSON.stringify({ userID: '1234' }),
+    } as unknown as Request;
+
+    const config = new Config();
+    await _request(
+      'http://localhost:3000',
+      { request, method: 'POST' },
+      config
+    );
+    const resolvedHeaders = {
+      ...requestHeaders,
+      'nile.origin': 'http://localhost:3001',
+      'content-type': 'application/x-www-form-urlencoded',
+    };
+
+    expect(setContext).toHaveBeenCalledWith(new Headers(resolvedHeaders));
+    expect(setCookie).toHaveBeenCalledWith(
+      new Headers({
+        'set-cookie': 'nile.session-token=123',
+      })
+    );
+  });
+});

--- a/packages/server/src/api/utils/request.ts
+++ b/packages/server/src/api/utils/request.ts
@@ -1,3 +1,4 @@
+import { setContext, setCookie } from '../../context/asyncStorage';
 import {
   X_NILE_ORIGIN,
   X_NILE_SECURECOOKIES,
@@ -42,9 +43,11 @@ export default async function request(
     updatedHeaders.set(X_NILE_ORIGIN, requestUrl.origin);
     debug(`Obtained origin from request ${requestUrl.origin}`);
   }
-
   const params = { ...init, headers: updatedHeaders };
-  if (params.method === 'POST' || params.method === 'PUT') {
+  if (
+    params.method?.toLowerCase() === 'post' ||
+    params.method?.toLowerCase() === 'put'
+  ) {
     try {
       updatedHeaders.set('content-type', 'application/json');
       const initBody = await new Response(_init.request.clone().body).json();
@@ -60,22 +63,28 @@ export default async function request(
 
   const fullUrl = `${url}${requestUrl.search}`;
   try {
-    const res = await fetch(fullUrl, { ...params }).catch((e) => {
-      error('An error has occurred in the fetch', {
-        message: e.message,
-        stack: e.stack,
-      });
-      return new Response(
-        'An unexpected (most likely configuration) problem has occurred',
-        { status: 500 }
-      );
-    });
+    setContext(updatedHeaders);
+    // set the headers so they can be used on subsequent server side requests
+    const res: Response | void = await fetch(fullUrl, { ...params }).catch(
+      (e) => {
+        error('An error has occurred in the fetch', {
+          message: e.message,
+          stack: e.stack,
+        });
+        return new Response(
+          'An unexpected (most likely configuration) problem has occurred',
+          { status: 500 }
+        );
+      }
+    );
     const loggingRes = typeof res?.clone === 'function' ? res?.clone() : null;
     info(`[${params.method ?? 'GET'}] ${fullUrl}`, {
       status: res?.status,
       statusText: res?.statusText,
       text: await loggingRes?.text(),
     });
+    // a special handler for a `set-cookie` header
+    setCookie(res?.headers);
     return res;
   } catch (e) {
     if (e instanceof Error) {

--- a/packages/server/src/auth/auth.test.ts
+++ b/packages/server/src/auth/auth.test.ts
@@ -21,7 +21,6 @@ const baseConfig = [
   'signOut',
 ];
 const apiConfig = [
-  '_token',
   'basePath',
   'callbackUrl',
   'cookieKey',

--- a/packages/server/src/context/asyncStorage.ts
+++ b/packages/server/src/context/asyncStorage.ts
@@ -1,0 +1,104 @@
+/**
+ * Acts as a bridge between `api.handlers` and the subsequent functions
+ */
+import {
+  X_NILE_ORIGIN,
+  X_NILE_TENANT,
+  X_NILE_USER_ID,
+} from '../utils/constants';
+
+type Optional = string | undefined | null;
+export type AsyncContext = {
+  origin?: Optional;
+  cookie?: Optional;
+  tenantId?: Optional;
+  userId?: Optional;
+};
+
+let globalContext: AsyncContext | null = null;
+
+export function setContext(headers: Headers) {
+  const origin = headers.get(X_NILE_ORIGIN);
+  const host = headers.get('host');
+  const cookie = headers.get('cookie');
+  const tenantId = headers.get(X_NILE_TENANT);
+  const userId = headers.get(X_NILE_USER_ID);
+  const context: AsyncContext = {};
+  if (origin) {
+    context.origin = origin;
+  } else if (host) {
+    context.origin = host;
+  }
+
+  if (cookie) {
+    context.cookie = cookie;
+  }
+
+  if (tenantId) {
+    context.tenantId = tenantId;
+  }
+  if (userId) {
+    context.userId = userId;
+  }
+  globalContext = context;
+}
+
+export function getOrigin(): Optional {
+  return globalContext?.origin;
+}
+
+export function getCookie(): Optional {
+  return globalContext?.cookie;
+}
+
+export function getTenantId(): Optional {
+  return globalContext?.tenantId;
+}
+export function getUserId(): Optional {
+  return globalContext?.userId;
+}
+
+// a special case where we have a `set-cookie` header
+export function setCookie(headers?: Headers) {
+  const getSet = headers?.getSetCookie?.();
+  if (getSet?.length) {
+    const updatedCookie: string[] = [];
+
+    for (const cook of getSet) {
+      const [c] = cook.split('; ');
+      const [, val] = c.split('=');
+      if (val) {
+        updatedCookie.push(c);
+      }
+    }
+
+    const cookie = mergeCookies(updatedCookie);
+    globalContext = { ...globalContext, cookie };
+  }
+}
+
+function mergeCookies(overrideArray: string[]): string {
+  const cookieString = getCookie();
+  const cookieMap: Record<string, string> = {};
+
+  if (!cookieString) {
+    return overrideArray.join('; ');
+  }
+  cookieString.split(';').forEach((cookie) => {
+    const [rawKey, ...rawVal] = cookie.trim().split('=');
+    const key = rawKey.trim();
+    const value = rawVal.join('=').trim(); // in case value has `=`
+    if (key) cookieMap[key] = value;
+  });
+
+  overrideArray.forEach((cookie) => {
+    const [rawKey, ...rawVal] = cookie.trim().split('=');
+    const key = rawKey.trim();
+    const value = rawVal.join('=').trim();
+    if (key) cookieMap[key] = value;
+  });
+
+  return Object.entries(cookieMap)
+    .map(([k, v]) => `${k}=${v}`)
+    .join('; ');
+}

--- a/packages/server/src/tenants/tenants.test.ts
+++ b/packages/server/src/tenants/tenants.test.ts
@@ -22,7 +22,6 @@ const baseConfig = [
   'password',
 ];
 const apiConfig = [
-  '_token',
   'basePath',
   'callbackUrl',
   'origin',

--- a/packages/server/src/users/users.test.ts
+++ b/packages/server/src/users/users.test.ts
@@ -25,7 +25,6 @@ const baseConfig = [
   'password',
 ];
 const apiConfig = [
-  '_token',
   'basePath',
   'origin',
   'callbackUrl',

--- a/packages/server/src/utils/Config/index.ts
+++ b/packages/server/src/utils/Config/index.ts
@@ -50,12 +50,13 @@ export class ApiConfig {
    */
   public callbackUrl?: string;
 
-  private _token?: string;
+  #token?: string;
+
   constructor(config?: ServerConfig, logger?: string) {
     const envVarConfig: EnvConfig = { config, logger };
 
     this.cookieKey = getCookieKey(envVarConfig);
-    this._token = getToken(envVarConfig);
+    this.#token = getToken(envVarConfig);
     this.callbackUrl = getCallbackUrl(envVarConfig);
     this.secureCookies = getSecureCookies(envVarConfig);
     this.basePath = getBasePath(envVarConfig);
@@ -66,11 +67,11 @@ export class ApiConfig {
   }
 
   public get token(): string | undefined {
-    return this._token;
+    return this.#token;
   }
 
   public set token(value: string | undefined) {
-    this._token = value;
+    this.#token = value;
   }
 }
 

--- a/packages/server/src/utils/Logger.ts
+++ b/packages/server/src/utils/Logger.ts
@@ -6,38 +6,49 @@ import { ServerConfig } from '../types';
 import { Config } from './Config';
 
 const red = '\x1b[31m';
-const yellow = '\x1b[33m';
+const yellow = '\x1b[38;2;255;255;0m';
+const purple = '\x1b[38;2;200;160;255m';
+const orange = '\x1b[38;2;255;165;0m';
 const reset = '\x1b[0m';
 
 const baseLogger = (config: void | ServerConfig, ...params: unknown[]) => ({
   info(message: string | unknown, meta?: Record<string, unknown>) {
     if (config?.debug) {
       console.info(
-        `[niledb][DEBUG]${params.join('')} ${message}`,
-        meta ? `\n${JSON.stringify(meta, null, 2)}` : ''
+        `${orange}[niledb]${reset}${purple}[DEBUG]${reset}${params.join(
+          ''
+        )}${reset} ${message}`,
+        meta ? `${JSON.stringify(meta)}` : ''
       );
     }
   },
   debug(message: string | unknown, meta?: Record<string, unknown>) {
     if (config?.debug) {
       console.debug(
-        `[niledb][DEBUG]${params.join('')} ${message}`,
-        meta ? `\n${JSON.stringify(meta, null, 2)}` : ''
+        `${orange}[niledb]${reset}${purple}[DEBUG]${reset}${params.join(
+          ''
+        )}${reset} ${message}`,
+        meta ? `${JSON.stringify(meta)}` : ''
       );
     }
   },
   warn(message: string | unknown, meta?: Record<string, unknown>) {
     if (config?.debug) {
       console.warn(
-        `${yellow}[niledb][WARN]${reset}${params.join('')} ${message}`,
-        JSON.stringify(meta, null, 2)
+        `${orange}[niledb]${reset}${yellow}[WARN]${reset}${params.join(
+          ''
+        )}${reset} ${message}`,
+        meta ? JSON.stringify(meta) : ''
       );
     }
   },
   error(message: string | unknown, meta?: Record<string, unknown>) {
     console.error(
-      `${red}[niledb][ERROR]${reset}${params.join('')} ${message}`,
-      meta
+      `${orange}[niledb]${reset}${red}[ERROR]${reset}${params.join(
+        ''
+      )}${red} ${message}`,
+      meta ? meta : '',
+      `${reset}`
     );
   },
 });

--- a/packages/server/src/utils/fetch.test.ts
+++ b/packages/server/src/utils/fetch.test.ts
@@ -1,32 +1,63 @@
+// Move the mock to the top
+jest.mock('../context/asyncStorage', () => ({
+  getCookie: jest.fn(),
+  getOrigin: jest.fn(),
+}));
+
+import { getCookie, getOrigin } from '../context/asyncStorage';
+
 import { Config } from './Config';
 import { X_NILE_SECURECOOKIES } from './constants';
 import { makeBasicHeaders } from './fetch';
 
 describe('fetch wrapper', () => {
-  it('sets application json', () => {
-    const config = new Config();
-    expect(Object.fromEntries(makeBasicHeaders(config).entries())).toEqual({
-      'content-type': 'application/json; charset=utf-8',
-    });
+  const url = '/';
+  beforeEach(() => {
+    jest.clearAllMocks(); // Reset all mocks before each test
   });
+
+  it('sets application json and uses the context', () => {
+    const config = new Config();
+    (getCookie as jest.Mock).mockReturnValue('nile.session-token=123');
+    (getOrigin as jest.Mock).mockReturnValue('http://some.url');
+
+    const result = Object.fromEntries(makeBasicHeaders(config, url).entries());
+
+    expect(result).toEqual({
+      'content-type': 'application/json; charset=utf-8',
+      cookie: 'nile.session-token=123',
+      'nile.origin': 'http://some.url',
+    });
+    expect(getCookie).toHaveBeenCalled();
+    expect(getOrigin).toHaveBeenCalled();
+  });
+
   it('makes the correct headers based on the config', () => {
     const config = new Config({ api: { secureCookies: true } });
-    expect(Object.fromEntries(makeBasicHeaders(config).entries())).toEqual({
+
+    const result = Object.fromEntries(makeBasicHeaders(config, url).entries());
+
+    expect(result).toEqual({
       'content-type': 'application/json; charset=utf-8',
+      cookie: 'nile.session-token=123',
+      'nile.origin': 'http://some.url',
       [X_NILE_SECURECOOKIES]: 'true',
     });
   });
-  it('passes headers on', () => {
+
+  it('passes the header cookie', () => {
     const config = new Config({ api: { secureCookies: true } });
-    expect(
-      Object.fromEntries(
-        makeBasicHeaders(config, {
-          headers: { cookie: '__Secure.nile-token=blah' },
-        }).entries()
-      )
-    ).toEqual({
+
+    const result = Object.fromEntries(
+      makeBasicHeaders(config, url, {
+        headers: { cookie: '__Secure.nile-token=blah' },
+      }).entries()
+    );
+
+    expect(result).toEqual({
       'content-type': 'application/json; charset=utf-8',
       cookie: '__Secure.nile-token=blah',
+      'nile.origin': 'http://some.url',
       [X_NILE_SECURECOOKIES]: 'true',
     });
   });


### PR DESCRIPTION
allows stuff like
```ts
import { NextRequest } from "next/server";
import { nile, handlers } from "../../../[...nile]/nile";

export async function GET(req: NextRequest) {
  await handlers.GET(req);
  const me = await nile.api.users.me();
  console.log(me);
  if ("id" in me) {
    console.log(me);
  }

```

to work, instead of having to parse headers and set them