### PR TITLE
Fix signIn helper name

### DIFF
--- a/packages/client/src/Authorizer.ts
+++ b/packages/client/src/Authorizer.ts
@@ -719,7 +719,7 @@ export const signOut: typeof authorizer.signOut = async function signOut(
 ) {
   return auth.signOut(options);
 };
-export const signIn: typeof authorizer.signIn = async function signOut(
+export const signIn: typeof authorizer.signIn = async function signIn(
   provider,
   options,
   authParams


### PR DESCRIPTION
## Summary
- correct `signIn` helper function name in client Authorizer

## Testing
- `yarn test:client` *(fails: Error when performing the request to https://repo.yarnpkg.com/4.5.0/packages/yarnpkg-cli/bin/yarn.js)*

------
https://chatgpt.com/codex/tasks/task_e_68501870dea48329a571b14cc21f7f15