### PR TITLE
fix(server): make nile.query and nile.db.query proxy for context

### DIFF
--- a/apps/nextjs-kitchensink/app/google/page.tsx
+++ b/apps/nextjs-kitchensink/app/google/page.tsx
@@ -11,10 +11,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 export default async function GooglePage() {
   const todos = await selectTodos();
-  const allTodos = await nile.noContext(async (_n) => {
-    const res = await _n.db.query('select * from todos2');
-    return res;
-  });
+  const allTodos = await nile.db.query('select * from todos2');
   return (
     <div className="container mx-auto pt-40">
       <div className="flex flex-col gap-4">

--- a/apps/nextjs-kitchensink/app/google/selectTodos.ts
+++ b/apps/nextjs-kitchensink/app/google/selectTodos.ts
@@ -2,7 +2,7 @@ import { nile } from '../api/[...nile]/nile';
 
 export default async function selectTodos() {
   const loggedIn = await nile.auth.getSession();
-  return loggedIn ? await nile.db.query('SELECT * FROM todos2') : { rows: [] };
+  return loggedIn ? await nile.query('SELECT * FROM todos2') : { rows: [] };
   /* 
   then display with something like  
   https://ui.shadcn.com/docs/components/data-table

--- a/packages/server/src/db/DBManager.ts
+++ b/packages/server/src/db/DBManager.ts
@@ -42,9 +42,9 @@ export default class DBManager {
     }
   };
 
-  getConnection = (config: Config): pg.Pool => {
+  getConnection = (config: Config, noContext = false): pg.Pool => {
     const { info } = Logger(config)('[DBManager]');
-    const { tenantId, userId } = ctx.getLastUsed();
+    const { tenantId, userId } = noContext ? {} : ctx.getLastUsed();
     const id = this.makeId(tenantId, userId);
 
     const existing = this.connections.get(id);
@@ -54,7 +54,7 @@ export default class DBManager {
       existing.startTimeout();
       return existing.pool;
     }
-    const newOne = new NileDatabase(config, id);
+    const newOne = new NileDatabase(config.db, config.logger, id);
     this.connections.set(id, newOne);
     info(`created new ${id}`);
     info(`# of instances: ${this.connections.size}`);

--- a/packages/server/src/db/NileInstance.test.ts
+++ b/packages/server/src/db/NileInstance.test.ts
@@ -13,7 +13,7 @@ describe('nile instance', () => {
         idleTimeoutMillis: 1,
       },
     });
-    new NileDatabase(config, 'someId');
+    new NileDatabase(config.db, config.logger, 'someId');
     watchEvictPool((id) => {
       expect(id).toEqual('someId');
       done();

--- a/packages/server/src/db/NileInstance.ts
+++ b/packages/server/src/db/NileInstance.ts
@@ -1,10 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import pg from 'pg';
+import pg, { PoolConfig } from 'pg';
 
-import { Config } from '../utils/Config';
 import { evictPool } from '../utils/Event';
-import { AfterCreate } from '../types';
-import { ctx } from '../api/utils/request-context';
+import { AfterCreate, NilePoolConfig } from '../types';
+import { Loggable, LogReturn } from '../utils/Logger';
 
 import { createProxyForPool } from './PoolProxy';
 
@@ -13,30 +12,35 @@ class NileDatabase {
   tenantId?: undefined | null | string;
   userId?: undefined | null | string;
   id: string;
-  config: Config;
+  logger: Loggable;
   timer: NodeJS.Timeout | undefined;
-
-  constructor(config: Config, id: string) {
-    const { warn, info, debug } = config.logger('[NileInstance]');
+  config: PoolConfig;
+  constructor(config: NilePoolConfig, logger: LogReturn, id: string) {
+    this.logger = logger('[NileInstance]');
     this.id = id;
     const poolConfig = {
       min: 0,
       max: 10,
       idleTimeoutMillis: 30000,
-      ...config.db,
+      ...config,
     };
     const { afterCreate, ...remaining } = poolConfig;
 
-    config.db = poolConfig;
-    this.config = config;
-    const cloned = { ...this.config.db };
-    cloned.password = '***';
-    debug(`Connection pool config ${JSON.stringify(cloned)}`);
+    this.config = remaining;
 
-    this.pool = createProxyForPool(new pg.Pool(remaining), this.config);
+    const cloned = { ...config };
+    cloned.password = '***';
+    this.logger.debug(`Connection pool config ${JSON.stringify(cloned)}`);
+
+    this.pool = createProxyForPool(
+      new pg.Pool(remaining),
+      this.config,
+      logger,
+      id === 'base' ? [] : id.split(':')
+    );
 
     if (typeof afterCreate === 'function') {
-      warn(
+      this.logger.warn(
         'Providing an pool configuration will stop automatic tenant context setting.'
       );
     }
@@ -44,14 +48,14 @@ class NileDatabase {
     // start the timer for cleanup
     this.startTimeout();
     this.pool.on('connect', async (client) => {
-      debug(`pool connected ${this.id}`);
+      this.logger.debug(`pool connected ${this.id}`);
       this.startTimeout();
       const afterCreate: AfterCreate = makeAfterCreate(
-        config,
-        `${this.id}-${this.timer}`
+        logger,
+        `${this.id}|${this.timer}`
       );
       afterCreate(client, (err) => {
-        const { error } = config.logger('[after create callback]');
+        const { error } = logger('[after create callback]');
         if (err) {
           clearTimeout(this.timer);
           error('after create failed', {
@@ -64,7 +68,7 @@ class NileDatabase {
     });
     this.pool.on('error', (err) => {
       clearTimeout(this.timer);
-      info(`pool ${this.id} failed`, {
+      this.logger.info(`pool ${this.id} failed`, {
         message: err.message,
         stack: err.stack,
       });
@@ -74,30 +78,30 @@ class NileDatabase {
       if (destroy) {
         clearTimeout(this.timer);
         evictPool(this.id);
-        debug(`destroying pool ${this.id}`);
+        this.logger.debug(`destroying pool ${this.id}`);
       }
     });
   }
 
   startTimeout() {
-    const { debug } = this.config.logger('[NileInstance]');
+    const { debug } = this.logger;
     if (this.timer) {
       clearTimeout(this.timer);
     }
     this.timer = setTimeout(() => {
       debug(
         `Pool reached idleTimeoutMillis. ${this.id} evicted after ${
-          Number(this.config.db.idleTimeoutMillis) ?? 30000
+          Number(this.config.idleTimeoutMillis) ?? 30000
         }ms`
       );
       this.pool.end(() => {
         clearTimeout(this.timer);
         evictPool(this.id);
       });
-    }, Number(this.config.db.idleTimeoutMillis) ?? 30000);
+    }, Number(this.config.idleTimeoutMillis) ?? 30000);
   }
   shutdown() {
-    const { debug } = this.config.logger('[NileInstance]');
+    const { debug } = this.logger;
     debug(`attempting to shut down ${this.id}`);
     clearTimeout(this.timer);
     this.pool.end(() => {
@@ -108,8 +112,8 @@ class NileDatabase {
 
 export default NileDatabase;
 
-function makeAfterCreate(config: Config, id: string): AfterCreate {
-  const { error, warn, debug } = config.logger('[afterCreate]');
+function makeAfterCreate(logger: LogReturn, id: string): AfterCreate {
+  const { error, warn, debug } = logger('[afterCreate]');
   return (conn, done) => {
     conn.on('error', function errorHandler(e: Error) {
       error(`Connection ${id} was terminated by server`, {
@@ -119,9 +123,10 @@ function makeAfterCreate(config: Config, id: string): AfterCreate {
       done(e, conn);
     });
 
-    // prefer context, I guess
-    const { tenantId, userId } = ctx.getLastUsed();
-    if (tenantId) {
+    const [context] = id.split('|');
+    // the main ctx may mutate independent of this, the config at instantiation is the source of truth
+    const [tenantId, userId] = context.split(':');
+    if (tenantId !== 'base') {
       const query = [`SET nile.tenant_id = '${tenantId}'`];
       if (userId) {
         if (!tenantId) {

--- a/packages/server/src/db/PoolProxy.ts
+++ b/packages/server/src/db/PoolProxy.ts
@@ -1,22 +1,28 @@
 import pg from 'pg';
 
-import { Config } from '../utils/Config';
+import { NilePoolConfig } from '../types';
+import { LogReturn } from '../utils/Logger';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AllowAny = any;
 
-export function createProxyForPool(pool: pg.Pool, config: Config): pg.Pool {
-  const { info, error } = config.logger('[pool]');
+export function createProxyForPool(
+  pool: pg.Pool,
+  config: NilePoolConfig,
+  logger: LogReturn,
+  context: string[]
+): pg.Pool {
+  const { info, error } = logger('[pool]');
   return new Proxy<pg.Pool>(pool, {
     get(target: AllowAny, property) {
       if (property === 'query') {
         // give connection string a pass for these problems
-        if (!config.db.connectionString) {
-          if (!config.db.user || !config.db.password) {
+        if (!config.connectionString) {
+          if (!config.user || !config.password) {
             error(
               'Cannot connect to the database. User and/or password are missing. Generate them at https://console.thenile.dev'
             );
-          } else if (!config.db.database) {
+          } else if (!config.database) {
             error(
               'Unable to obtain database name. Is process.env.NILEDB_POSTGRES_URL set?'
             );
@@ -25,7 +31,7 @@ export function createProxyForPool(pool: pg.Pool, config: Config): pg.Pool {
         const caller = target[property];
         return function query(...args: AllowAny) {
           let log = '[QUERY]';
-          const { userId, tenantId } = config.context;
+          const [tenantId, userId] = context;
           if (tenantId) {
             log = `${log}[TENANT:${tenantId}]`;
           }

--- a/packages/server/test/integration/integration.test.ts
+++ b/packages/server/test/integration/integration.test.ts
@@ -37,14 +37,11 @@ describe('api integration', () => {
     await initialDebugCleanup(nile);
     // make this user for later
     // you have to group things now that are "similar", else you will pollute everything.
-    const [tenantUser, verifiedMe] = await nile.withContext(
-      {},
-      async (nile) => {
-        const tenantUser = await nile.auth.signUp<User>(tu);
-        const verifiedMe = await nile.users.verifySelf<User>();
-        return [tenantUser, verifiedMe];
-      }
-    );
+    const [tenantUser, verifiedMe] = await nile.noContext(async (nile) => {
+      const tenantUser = await nile.auth.signUp<User>(tu);
+      const verifiedMe = await nile.users.verifySelf<User>();
+      return [tenantUser, verifiedMe];
+    });
 
     expect(verifiedMe.emailVerified).not.toBeNull();
 


### PR DESCRIPTION
in very basic apps, `nile.noContext` and `nile.withContext` gets weird when making db queries (still makes sense when doing requests, since the default will be `withContext` / extensions do ok when running.

this makes `nile.query` the context-aware call and makes `nile.db.query` as the non-context version one. It feels like there are a lot of non-addressed problems with the context in making app building easier. 

I need to figure out a solution that fixes this problem. 